### PR TITLE
Fix dictionary accessor

### DIFF
--- a/Sources/Bencode/BencodeKey.swift
+++ b/Sources/Bencode/BencodeKey.swift
@@ -26,6 +26,9 @@ extension BencodeKey: Hashable {
         return lhs.key == rhs.key
     }
     
+    public func hash(into hasher: inout Hasher {
+        hasher.combine(self.key)
+    }
 }
 
 extension BencodeKey: Comparable {


### PR DESCRIPTION
The subscript accessor currently fails to work because the hash includes the order and thus doesn't match during the lookup.

This makes the hash only include the properties that are compared for equality (aka. the key).